### PR TITLE
Full webcast and player controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This is Vbrick's JavaScript SDK library that enables you to embed Vbrick Rev web
 
 #### Accessing the SDK
 
-The JavaScript SDK can be accessed via `<script>` tag in your HTML. Set the src attribute to `https://<<YOUR_REV_URL>>/dist/rev-sdk.js` or import for ES6 module.
+The JavaScript SDK can be accessed via `<script>` tag in your HTML. Set the src attribute to `https://cdn.jsdelivr.net/npm/@vbrick/rev-sdk@latest/dist/rev-sdk.js` or import for ES6 module.
 
 ~~~
-<script src="https://<<YOUR_REV_URL>>/dist/rev-sdk.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vbrick/rev-sdk@latest/dist/rev-sdk.js"></script>
 
 <script type="module">
-  import revSdk from "https://<<YOUR_REV_URL>>/dist/rev-sdk.js";
+  import revSdk from "https://cdn.jsdelivr.net/npm/@vbrick/rev-sdk@latest/dist/rev-sdk.esm.js";
 </script>
 ~~~
 

--- a/demo/demoform.js
+++ b/demo/demoform.js
@@ -270,7 +270,7 @@ export function parseRevUrl(url) {
 		autoplay: 'autoplay',
 		forceClosedCaptions: 'forcedCaptions',
 		loopVideo: 'playInLoop',
-		noCc: 'hideCaptions',
+		noCc: 'hideSubtitles',
 		noCenterButtons: 'hideOverlayControls',
 		noChapters: 'hideChapters',
 		noFullscreen: 'hideFullscreen',
@@ -278,7 +278,8 @@ export function parseRevUrl(url) {
 		noSettings: 'hideSettings',
 		placeholder: 'popOut',
 		startAt: 'startAt',
-		popupAuth: 'popupAuth'
+		popupAuth: 'popupAuth',
+		enableFullRev: 'showFullWebcast'
 	};
 	const config = Array.from(searchParams.entries()).reduce((config, [key, value]) => {
 		const configKey = queryConfigMap[key];

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,9 +5,8 @@
 <head>
 	<style>
 		#embed {
-			height: 400px;
-			width: 700px;
-			margin: 20px;
+			height: 404px;
+			width: 720px;
 		}
 
 		form {
@@ -44,6 +43,22 @@
 
 		#demo {
 			display: flex;
+			gap: 20px;
+		}
+
+		.is-full-webcast #demo {
+			flex-wrap: wrap;
+		}
+
+		.is-full-webcast #embed {
+			max-width: 100%;
+			min-width: 480px;
+			box-sizing: border-box;
+			height: 576px;
+			flex: 1 0 1024px;
+		}
+		.is-full-webcast #controls {
+			flex: 1 1 auto;
 		}
 	</style>
 </head>
@@ -121,11 +136,15 @@
 				<div>
 					<div><b>Webcast Status: </b><span id="webcastStatus"></span></div>
 					<div><b>Player Status: </b><span id="playerStatus"></span></div>
+					<div><b>Current Time: </b><span id="currentTime"></span></div>
 				</div>
 				<div>
 					<button id="playButton">Play</button>
 					<button id="pauseButton">Pause</button>
-					Volume:<input type="range" id="volumeSlider" min="0" max="1"  step="0.01" />
+					<label for="volumeSlider">Volume: <input type="range" id="volumeSlider" min="0" max="1"  step="0.01" /></label>
+					<label for="subtitles">Subtitles: <select id="subtitles">
+						<option value="" default>None</option>
+					</select></label>
 				</div>
 			</div>
 		</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ts-loader": "^9.1.2",
         "typedoc": "^0.22.13",
         "typedoc-plugin-markdown": "^3.11.14",
-        "typescript": "^4.2.4",
+        "typescript": "^4.5.5",
         "webpack": "^5.36.2",
         "webpack-cli": "^4.7.0"
       }
@@ -3379,9 +3379,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6351,9 +6351,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ts-loader": "^9.1.2",
     "typedoc": "^0.22.13",
     "typedoc-plugin-markdown": "^3.11.14",
-    "typescript": "^4.2.4",
+    "typescript": "^4.5.5",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "module": "dist/rev-sdk.esm.js",
   "browser": "dist/rev-sdk.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/rev-sdk.d.ts",
   "browserslist": [
     "defaults",
     "not IE 11"

--- a/src/embed/EmbedVideo.ts
+++ b/src/embed/EmbedVideo.ts
@@ -21,6 +21,6 @@ export function embedVideo(
 	const cfg = resolveConfig(config);
 
 	const video = new VbrickVideoEmbed(videoId, cfg, el);
-	video.initialize();
+	video.initialize().catch(() => {});
 	return video;
 }

--- a/src/embed/EmbedWebcast.ts
+++ b/src/embed/EmbedWebcast.ts
@@ -35,7 +35,7 @@ export function embedWebcast(
 	const cfg = resolveConfig(config);
 
 	const webcast = new VbrickWebcastEmbed(webcastId, cfg, el);
-	webcast.initialize();
+	webcast.initialize().catch(() => {});
 	return webcast;
 }
 

--- a/src/embed/EventBus.ts
+++ b/src/embed/EventBus.ts
@@ -96,7 +96,9 @@ export class EventBus {
 			return;
 		}
 
-		this.shouldLog && console.log('rev SDK inbound message. ', e.data);
+		const shouldLog = this.shouldLog && data.event !== 'currentTime';
+
+		shouldLog && console.log('rev SDK inbound message. ', e.data);
 
 		this.callHandlers(data.event, data.msg);
 	}

--- a/src/embed/IVbrickApi.ts
+++ b/src/embed/IVbrickApi.ts
@@ -188,7 +188,7 @@ export interface ICaptionSettings {
 
 
 export interface ISDKVideoInfo {
-	id: string;
+	videoId: string;
 	title: string;
 	status: string;
 	duration: number;
@@ -213,6 +213,7 @@ export interface ISDKVideoInfo {
 
 // matches Public Get Webcast Status API (save the slidesUrl)
 export interface IWebcastInfo {
+	webcastId: string;
 	status: WebcastStatus;
 	isPreProduction?: boolean;
 	title: string;

--- a/src/embed/IVbrickApi.ts
+++ b/src/embed/IVbrickApi.ts
@@ -12,7 +12,7 @@ export interface IVbrickVideoEmbed extends IVbrickBaseEmbed {
 	/**
 	 * Fires when the video metadata is loaded
 	 */
-	on(event: 'videoLoaded', listener: (event: IVideoInfo) => void): void;
+	on(event: 'videoLoaded', listener: (event: ISDKVideoInfo) => void): void;
 
 	/**
 	 * Fired if the player volume changes
@@ -76,15 +76,13 @@ export interface IVbrickVideoEmbed extends IVbrickBaseEmbed {
 
 	/**
 	 * Whether captions are enabled, and selected language
-	 * @alpha
 	 */
 	readonly captions: ICaptionSettings;
 
 	/**
 	 * Contains metadata for the video
-	 * @beta
 	 */
-	readonly videoInfo: IVideoInfo;
+	readonly videoInfo: ISDKVideoInfo;
 
 	/**
 	 * Plays the video if it is paused.
@@ -182,19 +180,44 @@ export interface IVbrickBaseEmbed {
 	updateToken(token: VbrickSDKToken): void;
 }
 
-/**
- * @beta
- */
+
 export interface ICaptionSettings {
 	enabled: boolean;
-	language: string;
+	language?: 'captions' | string;
 }
 
-/**
- * @beta
- */
-export interface IVideoInfo {
+
+export interface ISDKVideoInfo {
 	id: string;
 	title: string;
-	description: string;
+	status: string;
+	duration: number;
+	isLive: boolean;
+	is360: boolean;
+	hasAudioOnly: boolean;
+	captions: Array<{ language: string }>;
+	chapters: Array<{
+		time: number;
+		imageId: string | null;
+		extension: string | null;
+		title: string | null;
+	}>;
+	playbacks: Array<{
+		id: string;
+		label: string;
+		streamDeliveryType: string;
+		zoneName: string | null;
+		deviceName: string | null;
+	}>;
+}
+
+// matches Public Get Webcast Status API (save the slidesUrl)
+export interface IWebcastInfo {
+	status: WebcastStatus;
+	isPreProduction?: boolean;
+	title: string;
+	startDate: string;
+	endDate: string;
+	captions: Array<{ language: string }>;
+	linkedVideoId?: string;
 }

--- a/src/embed/IVbrickApi.ts
+++ b/src/embed/IVbrickApi.ts
@@ -1,16 +1,18 @@
 import { WebcastStatus } from './WebcastStatus';
 import { PlayerStatus } from './PlayerStatus';
 import { VbrickSDKToken } from '../VbrickSDK';
-import { IHandlerArgs, TEmbedMessage, TPlayerMessage, TWebcastMessage } from './IVbrickEvents';
+import { TVbrickEvent, IListener, TEmbedMessages, TPlayerMessages, TWebcastMessages } from './IVbrickEvents';
 import { IVideoInfo, IWebcastInfo, IWebcastLayout, ISubtitles, IBasicInfo } from "./IVbrickTypes";
+
 export { WebcastStatus } from './WebcastStatus';
 export { PlayerStatus } from './PlayerStatus';
-
+export { TVbrickEvent, IListener, TEmbedMessages, TPlayerMessages, TWebcastMessages, TVbrickMessages } from './IVbrickEvents';
+export * from './IVbrickTypes';
 
 /**
  * @public
  */
-export interface IVbrickBaseEmbed<TMessages extends [string, ...any[]], TInfo extends IBasicInfo> {
+export interface IVbrickBaseEmbed<TInfo extends IBasicInfo, Events extends string & TVbrickEvent = keyof TEmbedMessages> {
 	/**
 	* video playing, buffering, etc
 	*/
@@ -49,7 +51,7 @@ export interface IVbrickBaseEmbed<TMessages extends [string, ...any[]], TInfo ex
 
 	/**
 	 * update the current subtitles settings
-	 * @param subtitles enable/disable subtitles and set language (use 'captions' for closed captions encoded into video stream)
+	 * @param subtitles - enable/disable subtitles and set language (use 'captions' for closed captions encoded into video stream)
 	 */
 	setSubtitles(subtitles: ISubtitles): void;
 
@@ -58,12 +60,12 @@ export interface IVbrickBaseEmbed<TMessages extends [string, ...any[]], TInfo ex
 	 * @param event - name of event
 	 * @param listener - callback when event is fired. Keep a reference if you intend to call {@link IVbrickBaseEmbed.off} later
 	 */
-	on(...[event, listener]: IHandlerArgs<TMessages>): void;
+	on<T extends Events>(event: T, listener: IListener<T>): void;
 
 	/**
 	 * Removes an event listener
 	 */
-	off(...[event, listener]: IHandlerArgs<TMessages>): void;
+	off<T extends Events>(event: T, listener: IListener<T>): void;
 
 	/**
 	 * Removes the embedded content from the DOM.
@@ -80,7 +82,7 @@ export interface IVbrickBaseEmbed<TMessages extends [string, ...any[]], TInfo ex
 /**
  * @public
  */
-export interface IVbrickVideoEmbed extends IVbrickBaseEmbed<TEmbedMessage | TPlayerMessage, IVideoInfo> {
+export interface IVbrickVideoEmbed extends IVbrickBaseEmbed<IVideoInfo, keyof (TEmbedMessages & TPlayerMessages)> {
 	/**
 	 * Current position in video in seconds
 	 */
@@ -99,13 +101,13 @@ export interface IVbrickVideoEmbed extends IVbrickBaseEmbed<TEmbedMessage | TPla
 
 	/**
 	 * sets playback rate 
-	 * @param speed {number} 0-16, default is 1
+	 * @param speed - 0-16, default is 1
 	 */
 	setPlaybackSpeed(speed: number): void;
 
 	/**
 	 * sets the current time in the video
-	 * @param currentTime {number} 0 - video duration
+	 * @param currentTime - value (in seconds) between 0 and video duration
 	 */
 	seek(currentTime: number): void;
 }
@@ -113,7 +115,7 @@ export interface IVbrickVideoEmbed extends IVbrickBaseEmbed<TEmbedMessage | TPla
 /**
  * @public
  */
-export interface IVbrickWebcastEmbed extends IVbrickBaseEmbed<TEmbedMessage | TPlayerMessage | TWebcastMessage, IWebcastInfo> {
+export interface IVbrickWebcastEmbed extends IVbrickBaseEmbed<IWebcastInfo, keyof (TEmbedMessages & TWebcastMessages)> {
 	/**
 	 * Indicates whether the webcast is started, or broadcasting.
 	 */
@@ -122,10 +124,7 @@ export interface IVbrickWebcastEmbed extends IVbrickBaseEmbed<TEmbedMessage | TP
 	/**
 	 * Change the visibility of video/slides. Only applicable when the "showFullWebcast" config
 	 * flag is enabled and the event includes slides
-	 * @param layout 
+	 * @param layout  - set if video/slides are displayed
 	 */
 	updateLayout(layout: IWebcastLayout): void;
-
-	on(...[event, listener]: IHandlerArgs<TEmbedMessage | TPlayerMessage | TWebcastMessage>): void;
-	off(...[event, listener]: IHandlerArgs<TEmbedMessage | TPlayerMessage | TWebcastMessage>): void;
 }

--- a/src/embed/IVbrickEvents.ts
+++ b/src/embed/IVbrickEvents.ts
@@ -1,0 +1,126 @@
+import { PlayerStatus } from './PlayerStatus';
+import { IVideoInfo, ISubtitles, IWebcastInfo, IWebcastStatusMessage, IWebcastLayout, IComment, ISlideEvent, IPoll, TPollId } from './IVbrickTypes';
+
+/**
+ * Authentication/load events 
+ * @public
+ */
+export type TEmbedMessage =
+	['load'] |
+	['authChanged'] |
+	['error', { msg: string; }];
+
+
+/**
+ * Video Player events
+ * @public
+ */
+ export type TPlayerMessage =
+	['videoLoaded', IVideoInfo] |
+	['playerStatusChanged', { status: PlayerStatus; }] |
+	['volumeChanged', number] |
+	['subtitlesChanged', ISubtitles] |
+	['playbackSpeedChanged', number] |
+	['seeked', { startTime: number, endTime: number; }] |
+	['currentTime', { currentTime: number, duration: number; }];
+
+/**
+ * Webcast events
+ * @public
+ */
+ export type TWebcastMessage =
+	/**
+	 * Metadata about the webcast
+	 */
+	['webcastLoaded', IWebcastInfo & IWebcastStatusMessage] |
+	['webcastStarted', IWebcastStatusMessage] |
+	['broadcastStarted', IWebcastStatusMessage] |
+	['broadcastStopped', IWebcastStatusMessage] |
+	['webcastEnded', IWebcastStatusMessage] |
+	['layoutChanged', IWebcastLayout] |
+	['commentAdded', IComment] |
+	['slideChanged', ISlideEvent] |
+	['pollOpened', IPoll] |
+	['pollClosed', TPollId] |
+	['pollPublished', IPoll] |
+	['pollUnpublished', TPollId];
+
+/**
+ * Tuples of emitted events and their payload types
+ * @public
+ */
+export type TVbrickMessage =
+	TEmbedMessage |
+	TPlayerMessage |
+	TWebcastMessage;
+
+/**
+ * Events emitted by Vbrick Embed
+ * @public
+ */
+export type TVbrickEvent = TVbrickMessage[0];
+
+/**
+ * A mapping of published events and a listener callback with the expected payload
+ * @public
+ */
+ export type IHandlerArgs<T extends [string, ...any[]]> = {
+	[K in T[0]]: [K, Handler<ValOfTuple<T, K>, void>]
+}[T[0]];
+
+//#region internal
+
+/**
+ * Messages sent to Rev via postMessage
+ * @internal
+ */
+export type TAuthMethods =
+	['authenticated', IAuthChangeRequest] |
+	['error', string] |
+	['authChanged', IAuthChangeRequest];
+
+
+/**
+* @internal
+*/
+export type TPlayerMethod =
+	['playVideo'] |
+	['pauseVideo'] |
+	['setPlaybackSpeed', { speed: number; }] |
+	['setVolume', { volume: number; }] |
+	['setSubtitles', ISubtitles] |
+	['seek', { currentTime: number; }];
+
+
+/**
+* @internal
+*/
+export type TWebcastMethod =
+	['updateLayout', IWebcastLayout];
+
+/**
+ * @internal
+ */
+interface IAuthChangeRequest {
+	token?: {
+		accessToken: string;
+	};
+}
+
+/**
+ * Events and the shape of the corresponding listener callback
+ * @internal
+ */
+export type TEventHandlers = {
+	[K in TVbrickEvent]: Handler<ValOfTuple<TVbrickMessage, K>, void>
+};
+
+type Handler<TIn, TOut> = TIn extends void
+	? () => TOut
+	: (...args: [TIn, ...any[]]) => TOut;
+
+export type ValOfTuple<T extends [string] | [string, ...any[]], K> = T extends [string, any]
+	? Extract<T, [K, any]>[1]
+	: void;
+
+

--- a/src/embed/IVbrickTypes.ts
+++ b/src/embed/IVbrickTypes.ts
@@ -1,0 +1,127 @@
+import { WebcastStatus } from './WebcastStatus';
+
+//#endregion internal
+/**
+ * The current subtitles language and if enabled or not
+ * @public
+ */
+
+export interface ISubtitles {
+	language?: string;
+	enabled: boolean;
+}
+/**
+ * Basic metadata shared between VOD and Webcast Embeds
+ * @public
+ */
+
+export interface IBasicInfo {
+	title: string;
+	isLive: boolean;
+	subtitles: Array<{ language: string; }>;
+}
+/**
+ * Video Metadata
+ * @public
+ */
+
+export interface IVideoInfo extends IBasicInfo {
+	videoId: string;
+	title: string;
+	status: string;
+	duration: number;
+	isLive: boolean;
+	is360: boolean;
+	hasAudioOnly: boolean;
+	subtitles: Array<{ language: string; }>;
+	chapters: Array<{
+		time: number;
+		imageId?: string;
+		extension?: string;
+		title?: string;
+	}>;
+	playbacks: Array<{
+		id: string;
+		label: string;
+		streamDeliveryType: string;
+		zoneName?: string;
+		deviceName?: string;
+	}>;
+}
+/**
+ * Event indicating the current webcast status
+ * @public
+ */
+
+export type IWebcastStatusMessage<T extends WebcastStatus = WebcastStatus> = {
+	status: T;
+	isPreProduction?: boolean;
+};
+/**
+ * Webcast Metadata
+ * @public
+ */
+
+export interface IWebcastInfo extends IBasicInfo {
+	webcastId: string;
+	title: string;
+	startDate: string;
+	endDate: string;
+	subtitles: Array<{ language: string; }>;
+	linkedVideoId?: string;
+	isLive: boolean;
+	isPreProduction?: boolean;
+}
+/**
+ * Fired when a new comment has been added to Chat
+ * @public
+ */
+
+export interface IComment {
+	comment: string;
+	date: string;
+	userId: string;
+	firstname?: string;
+	lastname?: string;
+}
+/**
+ * Details of the current slide on a Webcast slide change event
+ * @public
+ */
+
+export interface ISlideEvent {
+	slideNumber: number;
+	slideDelay: number;
+}
+/**
+ * Details of a Webcast Poll
+ * @public
+ */
+
+export interface IPoll {
+	// pollClosed only has pollId
+	pollId: string;
+	question: string;
+	// count only for poll published
+	answers: Array<{ text: string; count?: number; }>;
+	multipleChoice: boolean;
+	// only for poll published
+	totalResponses?: number;
+}
+/**
+ * The Webcast Poll that has been Closed/Unpublished
+ * @public
+ */
+
+export type TPollId = {
+	pollId: string;
+};
+/**
+ * Details of if Video and/or Slides are currently displayed
+ * @public
+ */
+
+export interface IWebcastLayout {
+	video?: boolean;
+	presentation?: boolean;
+}

--- a/src/embed/PlayerStatus.ts
+++ b/src/embed/PlayerStatus.ts
@@ -8,4 +8,5 @@ export enum PlayerStatus {
 	Buffering = 'Buffering',
 	Seeking = 'Seeking',
 	Ended = 'Ended',
+	Error = 'Error'
 }

--- a/src/embed/VbrickEmbed.ts
+++ b/src/embed/VbrickEmbed.ts
@@ -137,11 +137,15 @@ export abstract class VbrickEmbed<TInfo extends IBasicInfo> implements IVbrickBa
 		});
 	}
 	protected initializeEmbed(): void {
-		this.eventBus.on('videoLoaded', (e: any) => this._info = e);
+		this.eventBus.on('videoLoaded', (e: any) => {
+			this._info = e;
+			this._playerStatus = PlayerStatus.Paused;
+		});
 		//don't include status in information, since it can change
 		this.eventBus.on('webcastLoaded', ({status, ...info}: any) => {
 			this._info = info;
 		});
+		
 		this.eventBus.on('playerStatusChanged', e => this._playerStatus = e.status);
 		this.eventBus.on('subtitlesChanged', subtitles => {
 			this._currentSubtitles = subtitles;

--- a/src/embed/VbrickEmbed.ts
+++ b/src/embed/VbrickEmbed.ts
@@ -110,9 +110,7 @@ export abstract class VbrickEmbed<TInfo extends IBasicInfo> implements IVbrickBa
 			.then(([token]) => {
 				this.logger.log('embed loaded, authenticating');
 				this.eventBus.publish('authenticated', { token });
-				// added fail-safe check for if authChanged event isn't passed
-				// COMBAK - remove when confirmed unnecessary
-				this.eventBus.awaitEvent(['authChanged', 'videoLoaded', 'webcastLoaded'], 'error', timeout);
+				this.eventBus.awaitEvent('authChanged', 'error', timeout);
 			})
 			.catch(err => {
 				this._playerStatus = PlayerStatus.Error;

--- a/src/embed/VbrickEmbed.ts
+++ b/src/embed/VbrickEmbed.ts
@@ -10,16 +10,18 @@ import { VbrickSDKToken } from '../VbrickSDK';
 export abstract class VbrickEmbed implements IVbrickBaseEmbed {
 
 	protected iframe: HTMLIFrameElement;
+	protected readonly iframeUrl: string;
 	protected eventBus: EventBus;
 	private init: Promise<any>;
-	protected unsubscribes: Array<() => void>;
+	private unsubscribes: Array<() => void>;
 	protected logger: ILogger;
 
 	constructor(
-		protected readonly iframeUrl: string,
+		id: string,
 		protected readonly config: VbrickEmbedConfig,
 		protected readonly container: HTMLElement
 	) {
+		this.iframeUrl = this.getEmbedUrl(id, this.config);
 		this.logger = getLogger(this.config);
 	}
 
@@ -95,4 +97,5 @@ export abstract class VbrickEmbed implements IVbrickBaseEmbed {
 			this.eventBus.publish('authChanged', { token }))
 		.catch(e => this.logger.error('Error updating token: ', e));
 	}
+	protected abstract getEmbedUrl(id: string, config: VbrickEmbedConfig);
 }

--- a/src/embed/VbrickEmbed.ts
+++ b/src/embed/VbrickEmbed.ts
@@ -3,13 +3,13 @@ import { VbrickEmbedConfig } from './VbrickEmbedConfig';
 import { getLogger, ILogger } from '../Log';
 import { IVbrickBaseEmbed, PlayerStatus } from './IVbrickApi';
 import { TokenType, VbrickSDKToken } from '../VbrickSDK';
-import { IHandlerArgs, TEmbedMessage, TVbrickMessage } from './IVbrickEvents';
+import { TVbrickEvent, IListener } from './IVbrickEvents';
 import { IBasicInfo, ISubtitles } from './IVbrickTypes';
 
 /**
  * Base class for embedded content.
  */
-export abstract class VbrickEmbed<TInfo extends IBasicInfo> implements IVbrickBaseEmbed<TEmbedMessage, TInfo> {
+export abstract class VbrickEmbed<TInfo extends IBasicInfo> implements IVbrickBaseEmbed<TInfo> {
 
 	/**
 	* video playing, buffering, etc
@@ -151,12 +151,12 @@ export abstract class VbrickEmbed<TInfo extends IBasicInfo> implements IVbrickBa
 	}
 	protected abstract getEmbedUrl(id: string, config: VbrickEmbedConfig);
 	
-	public on(...[event, listener]: IHandlerArgs<TVbrickMessage>): void {
+	public on<T extends TVbrickEvent>(event: T, listener: IListener<T>): void {
 		//ensure internal updates take effect before calling client handlers
-		this.eventBus.on(event, (e: any) => setTimeout(() => listener(e)));
+		this.eventBus.on<any>(event, (e: any) => setTimeout(() => listener(e)));
 	}
 
-	public off(...[event, listener]: IHandlerArgs<TVbrickMessage>): void {
+	public off<T extends TVbrickEvent>(event: T, listener: IListener<T>): void {
 		this.eventBus.off(event, listener);
 	}
 

--- a/src/embed/VbrickEmbedConfig.ts
+++ b/src/embed/VbrickEmbedConfig.ts
@@ -27,7 +27,6 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
 
 	/**
 	 * seconds to wait for the embed initialization to complete. default is 30 seconds
-	 * @default 30
 	 */
 	timeoutSeconds?: number;
 }
@@ -42,7 +41,8 @@ export interface VbrickVideoEmbedConfig extends VbrickBaseEmbedConfig {
 	hideChapters?: boolean;
 	hideOverlayControls?: boolean;
 	hidePlayControls?: boolean;
-	hideCaptions?: boolean;
+	hideSubtitles?: boolean;
+	/** Use the Close Captions embedded in video stream as Subtitles */
 	forcedCaptions?: boolean;
 	hideSettings?: boolean;
 	hideFullscreen?: boolean;

--- a/src/embed/VbrickEmbedConfig.ts
+++ b/src/embed/VbrickEmbedConfig.ts
@@ -19,6 +19,13 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
 	 * Optional height to be set on embeds. Default is "100%"
 	 */
 	height?: string;
+
+	/**
+	 * For video embeds. If a user needs to log in, go through the login process in a popup window. This is the standard behavior for non-SDK Rev embeded videos
+	 */
+	popupAuth?: boolean;
+
+	autoplay?: boolean;
 }
 
 /**
@@ -26,12 +33,6 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
  * @public
  */
 export interface VbrickVideoEmbedConfig extends VbrickBaseEmbedConfig {
-	/**
-	 * For video embeds. If a user needs to log in, go through the login process in a popup window. This is the standard behavior for non-SDK Rev embeded videos
-	 */
-	popupAuth?: boolean;
-
-	autoplay?: boolean;
 	playInLoop?: boolean;
 	hideChapters?: boolean;
 	hideOverlayControls?: boolean;
@@ -63,6 +64,10 @@ export interface VbrickVideoEmbedConfig extends VbrickBaseEmbedConfig {
  * @public
  */
 export interface VbrickWebcastEmbedConfig extends VbrickBaseEmbedConfig {
+	/**
+	 * Include Chat, QA and Polls widgets in embed (if configured) 
+	 */
+	enableFullRev?: boolean;
 
 }
 

--- a/src/embed/VbrickEmbedConfig.ts
+++ b/src/embed/VbrickEmbedConfig.ts
@@ -24,8 +24,6 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
 	 * For video embeds. If a user needs to log in, go through the login process in a popup window. This is the standard behavior for non-SDK Rev embeded videos
 	 */
 	popupAuth?: boolean;
-
-	autoplay?: boolean;
 }
 
 /**
@@ -33,6 +31,7 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
  * @public
  */
 export interface VbrickVideoEmbedConfig extends VbrickBaseEmbedConfig {
+	autoplay?: boolean;
 	playInLoop?: boolean;
 	hideChapters?: boolean;
 	hideOverlayControls?: boolean;
@@ -67,7 +66,7 @@ export interface VbrickWebcastEmbedConfig extends VbrickBaseEmbedConfig {
 	/**
 	 * Include Chat, QA and Polls widgets in embed (if configured) 
 	 */
-	enableFullRev?: boolean;
+	showFullWebcast?: boolean;
 
 }
 

--- a/src/embed/VbrickEmbedConfig.ts
+++ b/src/embed/VbrickEmbedConfig.ts
@@ -24,6 +24,12 @@ export interface VbrickBaseEmbedConfig extends VbrickSDKConfig {
 	 * For video embeds. If a user needs to log in, go through the login process in a popup window. This is the standard behavior for non-SDK Rev embeded videos
 	 */
 	popupAuth?: boolean;
+
+	/**
+	 * seconds to wait for the embed initialization to complete. default is 30 seconds
+	 * @default 30
+	 */
+	timeoutSeconds?: number;
 }
 
 /**

--- a/src/embed/VbrickEmbedConfig.ts
+++ b/src/embed/VbrickEmbedConfig.ts
@@ -80,4 +80,4 @@ export interface VbrickWebcastEmbedConfig extends VbrickBaseEmbedConfig {
  * Options available when embedding a VOD/video or webcast
  * @public
  */
-export type VbrickEmbedConfig = VbrickVideoEmbedConfig & VbrickWebcastEmbedConfig;
+export interface VbrickEmbedConfig extends VbrickVideoEmbedConfig, VbrickWebcastEmbedConfig {}

--- a/src/embed/VbrickVideoEmbed.ts
+++ b/src/embed/VbrickVideoEmbed.ts
@@ -16,7 +16,7 @@ export class VbrickVideoEmbed extends VbrickEmbed implements IVbrickVideoEmbed {
 	public get playerStatus(): PlayerStatus {
 		return this._playerStatus;
 	}
-	private _playerStatus
+	private _playerStatus = PlayerStatus.Initializing;
 
 	 /**
 	 * Player Volume. 0-1
@@ -120,6 +120,14 @@ export class VbrickVideoEmbed extends VbrickEmbed implements IVbrickVideoEmbed {
 	 */
 	public setCaptions(captions: ICaptionSettings) {
 		this.eventBus.publish('setCaptions', captions);
+	}
+
+	public initialize(): Promise<void> {
+		const whenInitialized = super.initialize();
+		whenInitialized.catch(() => {
+			this._playerStatus = PlayerStatus.Error;
+		});
+		return whenInitialized;
 	}
 
 	protected initializeToken(): Promise<any> {

--- a/src/embed/VbrickWebcastEmbed.ts
+++ b/src/embed/VbrickWebcastEmbed.ts
@@ -17,7 +17,7 @@ export class VbrickWebcastEmbed extends VbrickEmbed implements IVbrickWebcastEmb
 		config: VbrickWebcastEmbedConfig,
 		container: HTMLElement
 	) {
-		super(new URL(`/embed/webcast/${webcastId}${config.token ? '?tk' : ''}`, config.baseUrl).toString(), config, container);
+		super(getEmbedUrl(webcastId, config), config, container);
 	}
 
 	protected initializeToken(): Promise<VbrickSDKToken> {
@@ -33,5 +33,21 @@ export class VbrickWebcastEmbed extends VbrickEmbed implements IVbrickWebcastEmb
 			this._webcastStatus = data.status;
 		});
 	}
+}
 
+function getEmbedUrl(id: string, config: VbrickWebcastEmbedConfig): string {
+	const query = [
+		['tk', !!config.token],
+		['autoplay', config.autoplay],
+		['popupAuth', !config.token && (config.popupAuth ? 'true' : 'false')],
+		['enableFullRev', config.enableFullRev]
+	]
+		.map(([key, value]) =>
+			!value ? undefined :
+			value === true ? key :
+			`${key}=${encodeURIComponent(value)}`)
+		.filter(Boolean)
+		.join('&');
+
+	return `${config.baseUrl}/embed/webcast/${id}?${query}`;
 }

--- a/src/embed/VbrickWebcastEmbed.ts
+++ b/src/embed/VbrickWebcastEmbed.ts
@@ -3,7 +3,6 @@ import { IVbrickWebcastEmbed, WebcastStatus } from './IVbrickApi';
 import { initializeWebcastToken } from './webcastAuth';
 import { VbrickEmbedConfig, VbrickWebcastEmbedConfig } from './VbrickEmbedConfig';
 import { getEmbedUrl } from '../util';
-import { TVbrickEvent } from './IVbrickEvents';
 import { IWebcastInfo, IWebcastLayout } from "./IVbrickTypes";
 import { getEmbedQuery, VbrickEmbed } from './VbrickEmbed';
 
@@ -29,7 +28,7 @@ export class VbrickWebcastEmbed extends VbrickEmbed<IWebcastInfo> implements IVb
 	protected async initializeEmbed(): Promise<void> {
 		super.initializeEmbed();
 
-		['webcastStarted', 'broadcastStarted', 'broadcastStopped', 'webcastEnded'].forEach((event: TVbrickEvent) => {
+		(<const>['webcastStarted', 'broadcastStarted', 'broadcastStopped', 'webcastEnded']).forEach(event => {
 			this.eventBus.on(event, data => this._webcastStatus = data.status);
 		});
 

--- a/src/embed/VbrickWebcastEmbed.ts
+++ b/src/embed/VbrickWebcastEmbed.ts
@@ -49,4 +49,7 @@ function getEmbedUrl(id: string, config: VbrickWebcastEmbedConfig): string {
 		.join('&');
 
 	return `${config.baseUrl}/embed/webcast/${id}?${query}`;
+	public updateLayout(layout: { video?: boolean, presentation?: boolean}) {
+		this.eventBus.publish('updateLayout', layout);
+	}
 }

--- a/src/embed/VbrickWebcastEmbed.ts
+++ b/src/embed/VbrickWebcastEmbed.ts
@@ -38,9 +38,8 @@ export class VbrickWebcastEmbed extends VbrickEmbed implements IVbrickWebcastEmb
 function getEmbedUrl(id: string, config: VbrickWebcastEmbedConfig): string {
 	const query = [
 		['tk', !!config.token],
-		['autoplay', config.autoplay],
 		['popupAuth', !config.token && (config.popupAuth ? 'true' : 'false')],
-		['enableFullRev', config.enableFullRev]
+		['enableFullRev', config.showFullWebcast]
 	]
 		.map(([key, value]) =>
 			!value ? undefined :

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,3 +17,15 @@ export function lookupElement(element: string | HTMLElement): HTMLElement {
 
 	return el;
 }
+
+export function getEmbedUrl(baseUrl: string, endpoint: string, params: Record<string, any>) {
+	const query = Object.entries(params)
+		.map(([key, value]) =>
+			!value ? undefined :
+			value === true ? key :
+			`${key}=${encodeURIComponent(value)}`)
+		.filter(Boolean)
+		.join('&');
+
+	return `${baseUrl}${endpoint}?${query}`;
+}


### PR DESCRIPTION
* Support full webcast experience (Chat, Polls, QA)
* Support subtitles, seeking, and other player controls.
* Brings SDK into parity with methods/events supported by player.js (including currentTime)
* deprectate `videoInfo` and change to `info` - included for Videos and Webcasts
* Change default URL to library in readme link
* Handle async authentication confirmation/rejection
* Refactor Embed classes/types